### PR TITLE
Refer to #1 - Fix: Prevent exponential ball growth on multi-ball pickup

### DIFF
--- a/script.js
+++ b/script.js
@@ -371,9 +371,13 @@ function activatePowerUp(type) {
     switch(type) {
         case 'multiBall':
             if (gameState.balls.length < 5) {
-                gameState.balls.forEach(ball => {
-                    gameState.balls.push({...ball});
-                });
+                // gameState.balls.forEach(ball => {
+                //     gameState.balls.push({...ball});
+                // });
+                // Add two new balls with slightly different trajectories
+    gameState.balls.push({ ...gameState.balls[0], dx: -gameState.balls[0].dx });
+    gameState.balls.push({ ...gameState.balls[0], dy: Math.abs(gameState.balls[0].dy) });
+
             }
             gameState.powerups.multiBall.active = true;
             gameState.powerups.multiBall.activationTime = currentTime;

--- a/script.js
+++ b/script.js
@@ -370,7 +370,7 @@ function activatePowerUp(type) {
     
     switch(type) {
         case 'multiBall':
-            if (gameState.balls.length < 3) {
+            if (gameState.balls.length < 4) {
                 // gameState.balls.forEach(ball => {
                 //     gameState.balls.push({...ball});
                 // });

--- a/script.js
+++ b/script.js
@@ -370,7 +370,7 @@ function activatePowerUp(type) {
     
     switch(type) {
         case 'multiBall':
-            if (gameState.balls.length < 5) {
+            if (gameState.balls.length < 3) {
                 // gameState.balls.forEach(ball => {
                 //     gameState.balls.push({...ball});
                 // });


### PR DESCRIPTION
This PR addresses the performance issues (exponential lag) caused when multiple multi-ball power-ups are active simultaneously. Previously, the logic doubled every existing ball on the screen, leading to an unmanageable number of entities.

The logic has been updated to add exactly two new balls per power-up instance, providing a balanced gameplay experience without crashing the game.

This might potentially fix #1  